### PR TITLE
Fix display matrix retrieval without deprecated API

### DIFF
--- a/src/audio/audio_reader.cc
+++ b/src/audio/audio_reader.cc
@@ -148,7 +148,6 @@ namespace decord {
         if (codecOpenRet < 0) {
             char errstr[200];
             av_strerror(codecOpenRet, errstr, 200);
-            avcodec_close(pCodecContext);
             avcodec_free_context(&pCodecContext);
             avformat_close_input(&pFormatContext);
             LOG(FATAL) << "ERROR open codec through avcodec_open2: " << errstr;
@@ -210,7 +209,6 @@ namespace decord {
         // clean up
         av_frame_free(&pFrame);
         av_packet_free(&pPacket);
-        avcodec_close(pCodecContext);
         swr_close(swr);
         swr_free(&swr);
         avcodec_free_context(&pCodecContext);

--- a/src/video/ffmpeg/filter_graph.cc
+++ b/src/video/ffmpeg/filter_graph.cc
@@ -63,14 +63,12 @@ void FFMPEGFilterGraph::Init(std::string filters_descr, AVCodecContext *dec_ctx)
     // LOG(INFO) << "create filter src";
 
     /* buffer video sink: to terminate the filter chain. */
-	// buffersink_params = av_buffersink_params_alloc();
-	// buffersink_params->pixel_fmts = pix_fmts;
-	CHECK_GE(avfilter_graph_create_filter(&buffersink_ctx_, buffersink, "out",
-		NULL, NULL, filter_graph_.get()), 0) << "Cannot create buffer sink";
-	// av_free(buffersink_params);
+        AVBufferSinkParams *buffersink_params = av_buffersink_params_alloc();
+        buffersink_params->pixel_fmts = pix_fmts;
+        CHECK_GE(avfilter_graph_create_filter(&buffersink_ctx_, buffersink, "out",
+                NULL, buffersink_params, filter_graph_.get()), 0) << "Cannot create buffer sink";
+        av_free(buffersink_params);
     // LOG(INFO) << "create filter sink";
-    // CHECK_GE(av_opt_set_bin(buffersink_ctx_, "pix_fmts", (uint8_t *)&pix_fmts, sizeof(AV_PIX_FMT_RGB24), AV_OPT_SEARCH_CHILDREN), 0) << "Set bin error";
-    CHECK_GE(av_opt_set_int_list(buffersink_ctx_, "pix_fmts", pix_fmts, AV_PIX_FMT_NONE, AV_OPT_SEARCH_CHILDREN), 0) << "Set output pixel format error.";
 
     // LOG(INFO) << "create filter set opt";
     /* Endpoints for the filter graph. */

--- a/src/video/video_reader.cc
+++ b/src/video/video_reader.cc
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <decord/runtime/ndarray.h>
 #include <decord/runtime/c_runtime_api.h>
+#include <libavutil/display.h>
 
 namespace decord {
 
@@ -548,18 +549,31 @@ double VideoReader::GetRotation() const {
     CHECK(actv_stm_idx_ >= 0);
     CHECK(static_cast<unsigned int>(actv_stm_idx_) < fmt_ctx_->nb_streams);
     AVStream *active_st = fmt_ctx_->streams[actv_stm_idx_];
-    AVDictionaryEntry *rotate = av_dict_get(active_st->metadata, "rotate", NULL, 0);
-
     double theta = 0;
-    if (rotate && *rotate->value && strcmp(rotate->value, "0"))
+#if LIBAVFORMAT_VERSION_MAJOR >= 60
+    AVDictionaryEntry *rotate = av_dict_get(active_st->metadata, "rotate", NULL, 0);
+    if (rotate && rotate->value && strcmp(rotate->value, "0")) {
         theta = atof(rotate->value);
-
-    uint8_t* displaymatrix = av_stream_get_side_data(active_st, AV_PKT_DATA_DISPLAYMATRIX, NULL);
-    if (displaymatrix && !theta)
-        theta = -av_display_rotation_get((int32_t*) displaymatrix);
-
+    }
+#else
+    uint8_t *displaymatrix = nullptr;
+    for (int i = 0; i < active_st->nb_side_data; ++i) {
+        if (active_st->side_data[i].type == AV_PKT_DATA_DISPLAYMATRIX) {
+            displaymatrix = active_st->side_data[i].data;
+            break;
+        }
+    }
+    if (displaymatrix) {
+        theta = -av_display_rotation_get(reinterpret_cast<int32_t *>(displaymatrix));
+    } else {
+        AVDictionaryEntry *rotate = av_dict_get(active_st->metadata, "rotate", NULL, 0);
+        if (rotate && rotate->value && strcmp(rotate->value, "0")) {
+            theta = atof(rotate->value);
+        }
+    }
+#endif
     theta = std::fmod(theta, 360);
-    if(theta < 0) theta += 360;
+    if (theta < 0) theta += 360;
 
     return theta;
 }


### PR DESCRIPTION
## Summary
- avoid `av_stream_get_side_data` by scanning `AVStream` side data when available
- configure filter graph buffersink with `AVBufferSinkParams` instead of `av_opt_set_int_list`

## Testing
- `python scripts/fetch-vendor.py --config-file scripts/ffmpeg-8.0.json /tmp/vendor` *(curl: (56) failure to download ffmpeg archive)*
- `mkdir build && cd build && cmake .. && make -j2` *(Unable to find FFMPEG automatically)*
- `pytest -q` *(ModuleNotFoundError: No module named 'decord')*

------
https://chatgpt.com/codex/tasks/task_b_68aad56fa1908330a633d2f9a49193eb